### PR TITLE
feat: disable Chroma telemetry and add embeddings maintenance tooling

### DIFF
--- a/.github/workflows/ci-embeddings.yml
+++ b/.github/workflows/ci-embeddings.yml
@@ -1,0 +1,27 @@
+name: CI Embeddings
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
 # PDF-to-PKL
+
+Instrument pentru conversia materialelor educaționale PDF în embeddings Chroma, cu accent pe rularea în medii restricționate precum Railway.
+
+## Variabile de mediu cheie
+
+| Variabilă | Implicit | Descriere |
+|-----------|----------|-----------|
+| `EMBEDDINGS_DB_PATH` | `./embeddings_db` | Directorul persistent pentru baza Chroma. Este creat automat dacă nu există. |
+| `CHUNK_SIZE` | configurarea din `config.py` (fallback 800 când valoarea introdusă nu este validă) | Dimensiunea chunk-urilor generate din PDF. |
+| `CHUNK_OVERLAP` | configurarea din `config.py` (fallback 120 când valoarea introdusă nu este validă) | Suprapunerea dintre chunk-uri consecutive. |
+| `CHROMA_TELEMETRY` | `0` | Setează `0` pentru a opri telemetria Posthog/Chroma. Orice altă valoare reactivează raportarea anonimă. |
+| `KEYWORD_SWEEP_OUTPUT` | `keyword_sweep.csv` | (Opțional) Path implicit pentru exportul utilitarului de sweep semantic. |
+
+> **Notă:** Valorile invalide pentru `CHUNK_SIZE`/`CHUNK_OVERLAP` sunt înlocuite la runtime cu fallback-uri conservatoare (800/120) pentru a evita erori la deploy.
+
+## CLI & întreținere index
+
+Scriptul principal oferă un mic CLI pentru operațiuni de mentenanță:
+
+```bash
+python pdf_converter_working.py --prune-collections        # Șterge colecțiile goale și cele prefixate cu tmp_
+python pdf_converter_working.py --prune-collections --dry-run
+python pdf_converter_working.py --snapshot-db              # Creează un snapshot în ./snapshots/
+python pdf_converter_working.py --snapshot-db --snapshot-dest /var/backups
+```
+
+### Sweep semantic rapid
+
+Utilitarul `tools/keyword_sweep.py` e gândit pentru verificare rapidă a calității embeddings-urilor fără a modifica indexul:
+
+```bash
+python tools/keyword_sweep.py \
+  --keywords "copil, programă, exercițiu, Piaget" \
+  --output data/keyword_sweep.csv \
+  --top-k 3
+```
+
+CSV-ul rezultat conține coloanele: `keyword`, `collection`, `hit_count`, `first_hit_id`, `first_hit_page`, `latency_ms`.
+
+## Deploy pe Railway
+
+1. **Construiește imaginea** folosind `Dockerfile` furnizat sau `railway up`.
+2. **Configurare variabile de mediu** din dashboard:
+   - `EMBEDDINGS_DB_PATH=/data/embeddings_db`
+   - `CHROMA_TELEMETRY=0`
+   - (opțional) `CHUNK_SIZE` și `CHUNK_OVERLAP` pentru ajustări runtime.
+3. **Persistă datele** montând un volum la `EMBEDDINGS_DB_PATH` (ex: `/data`).
+4. **Rulează probele** după deploy: `python pdf_converter_working.py --prune-collections --dry-run` și `python tools/keyword_sweep.py --top-k 2` pentru a verifica conectivitatea către baza de embeddings.
+5. **Monitorizare**: logurile vor raporta configurarea chunk-urilor la startup și eventualele clamp-uri `top_k` atunci când dimensiunea colecției este depășită.
+
+## Testare
+
+Rularea testelor unitare se face cu:
+
+```bash
+pytest
+```
+
+Acoperirea include probele modelului, verificarea dezactivării telemetriei și a faptului că interogările nu introduc duplicate în rezultate.

--- a/config.py
+++ b/config.py
@@ -78,7 +78,16 @@ def load_config_from_env():
     if os.getenv("EMBEDDING_MODEL"):
         EMBEDDING_CONFIG.model = os.getenv("EMBEDDING_MODEL")
     if os.getenv("CHUNK_SIZE"):
-        EMBEDDING_CONFIG.chunk_size = int(os.getenv("CHUNK_SIZE"))
+        try:
+            EMBEDDING_CONFIG.chunk_size = int(os.getenv("CHUNK_SIZE"))
+        except ValueError:
+            # Valoare fallback recomandată pentru deployment-uri restricționate
+            EMBEDDING_CONFIG.chunk_size = 800
+    if os.getenv("CHUNK_OVERLAP"):
+        try:
+            EMBEDDING_CONFIG.overlap = int(os.getenv("CHUNK_OVERLAP"))
+        except ValueError:
+            EMBEDDING_CONFIG.overlap = 120
     if os.getenv("BATCH_SIZE"):
         EMBEDDING_CONFIG.batch_size = int(os.getenv("BATCH_SIZE"))
     

--- a/test_carl_jung_safe.py
+++ b/test_carl_jung_safe.py
@@ -1,10 +1,16 @@
 import os
 import time
+
+import pytest
+
 from pdf_converter_working import PDFEmbeddingsConverter
 
 def test_with_memory_limits():
     test_dir = r'C:\Users\Opaop\Desktop\Conversie PDF to PKL\PDF_to_Embeddings\materiale_didactice\Scoala_de_Muzica_George_Enescu\clasa_2\Dezvoltare_personala\Prof_Carl_Jung'
-    
+
+    if not os.path.exists(test_dir):
+        pytest.skip("Materialele Carl Jung nu sunt disponibile în mediul de test")
+
     converter = PDFEmbeddingsConverter()
     
     # Gaseste PDF-urile

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,110 @@
+import os
+from types import SimpleNamespace
+from typing import List
+
+import numpy as np
+import pytest
+
+import pdf_converter_working as converter_module
+from pdf_converter_working import PDFEmbeddingsConverter
+
+
+class FakeModel:
+    def encode(self, sentences: List[str], normalize_embeddings: bool = True):
+        return np.ones((len(sentences), 3), dtype=np.float32)
+
+
+class FakeCollection:
+    def __init__(self, name: str, documents: List[str], ids: List[str]):
+        self.name = name
+        self._documents = documents
+        self._ids = ids
+        self._metadatas = [{"page_from": index + 1} for index, _ in enumerate(documents)]
+        self._distances = [0.1 for _ in documents]
+        self.add_called = False
+        self.last_n_results = None
+
+    def count(self):
+        return len(self._documents)
+
+    def query(self, query_embeddings, n_results: int):
+        self.last_n_results = n_results
+        limit = min(n_results, len(self._documents))
+        return {
+            "documents": [self._documents[:limit]],
+            "metadatas": [self._metadatas[:limit]],
+            "distances": [self._distances[:limit]],
+            "ids": [self._ids[:limit]],
+        }
+
+    def add(self, *args, **kwargs):  # pragma: no cover - should never be called
+        self.add_called = True
+
+
+class FakeClient:
+    def __init__(self, collections):
+        self._collections = {collection.name: collection for collection in collections}
+
+    def list_collections(self):
+        return list(self._collections.values())
+
+    def get_collection(self, name):
+        return self._collections[name]
+
+    def delete_collection(self, name):
+        self._collections.pop(name, None)
+
+
+@pytest.fixture
+def converter():
+    instance = PDFEmbeddingsConverter.__new__(PDFEmbeddingsConverter)
+    instance.model = FakeModel()
+    documents = ["Primul document", "Al doilea document", "Al treilea document", "Primul document"]
+    ids = ["doc-1", "doc-2", "doc-3", "doc-1"]
+    collection = FakeCollection("educatie", documents, ids)
+    instance.client = FakeClient([collection])
+    return instance
+
+
+def test_model_probe_runs():
+    instance = PDFEmbeddingsConverter.__new__(PDFEmbeddingsConverter)
+    instance.model = FakeModel()
+    assert instance.test_model() is True
+
+
+def test_query_no_add_and_no_duplicates(converter):
+    result = converter.search_similar("învățare", top_k=5)
+
+    # asigură-te că add nu a fost apelat în timpul căutării
+    collection = converter.client.get_collection("educatie")
+    assert collection.add_called is False
+
+    returned_ids = result["ids"][0]
+    assert len(returned_ids) == len(set(returned_ids))
+
+
+def test_topk_clamped_to_collection_size(converter, caplog):
+    caplog.set_level("INFO")
+    converter.search_similar("învățare", top_k=10)
+    collection = converter.client.get_collection("educatie")
+
+    assert collection.last_n_results == collection.count()
+    assert any("Clamped top_k" in record.message for record in caplog.records)
+
+
+def test_telemetry_off_when_env_set(monkeypatch):
+    instance = PDFEmbeddingsConverter.__new__(PDFEmbeddingsConverter)
+    os.environ["CHROMA_TELEMETRY"] = "0"
+    captured = {}
+
+    def fake_client(path, settings):
+        captured["path"] = path
+        captured["settings"] = settings
+        return SimpleNamespace(path=path, settings=settings)
+
+    monkeypatch.setattr(converter_module.chromadb, "PersistentClient", fake_client)
+
+    client = instance._create_chroma_client("/tmp/embeddings")
+    assert client.path == "/tmp/embeddings"
+    assert getattr(captured["settings"], "anonymized_telemetry", None) is False
+    monkeypatch.delenv("CHROMA_TELEMETRY", raising=False)

--- a/tools/keyword_sweep.py
+++ b/tools/keyword_sweep.py
@@ -1,0 +1,143 @@
+"""Utility pentru sweep semantic rapid pe colecțiile Chroma."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import time
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from pdf_converter_working import PDFEmbeddingsConverter
+
+DEFAULT_KEYWORDS = [
+    "copil",
+    "programă",
+    "exercițiu",
+    "Piaget",
+    "Feuerstein",
+    "muzică",
+    "ritm",
+    "fracții",
+    "evaluare",
+    "lectură",
+    "creativitate",
+    "emoție",
+    "STEM",
+    "istorie",
+    "geografie",
+    "chimie",
+    "literatură",
+    "soft skills",
+    "arte vizuale",
+    "sport",
+]
+
+
+def _parse_keyword_source(keyword_source: Optional[str]) -> List[str]:
+    if not keyword_source:
+        return DEFAULT_KEYWORDS
+
+    path = Path(keyword_source)
+    if path.exists():
+        content = path.read_text(encoding="utf-8")
+    else:
+        content = keyword_source
+
+    separators = [",", "\n", "\r"]
+    for separator in separators:
+        content = content.replace(separator, " ")
+
+    keywords = [token.strip() for token in content.split(" ") if token.strip()]
+    return keywords or DEFAULT_KEYWORDS
+
+
+def _extract_first_page(metadata: Optional[dict]) -> Optional[int]:
+    if not metadata:
+        return None
+
+    for key in ("page_from", "page", "page_start", "page_number"):
+        value = metadata.get(key)
+        if isinstance(value, int):
+            return value
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def keyword_sweep(
+    keywords: Iterable[str],
+    output_path: Path,
+    top_k: int = 3,
+) -> Path:
+    converter = PDFEmbeddingsConverter()
+    collections = converter.client.list_collections()
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with output_path.open("w", encoding="utf-8", newline="") as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow(["keyword", "collection", "hit_count", "first_hit_id", "first_hit_page", "latency_ms"])
+
+        for collection in collections:
+            collection_name = getattr(collection, "name", "unknown")
+            for keyword in keywords:
+                start_time = time.time()
+                results = converter.search_similar(keyword, top_k=top_k, collection_name=collection_name)
+                latency_ms = round((time.time() - start_time) * 1000, 2)
+
+                docs = results.get("documents", [[]])[0] if results else []
+                metadatas = results.get("metadatas", [[]])[0] if results else []
+                ids = results.get("ids", [[]])[0] if results else []
+
+                first_hit_id = ids[0] if ids else ""
+                first_hit_page = _extract_first_page(metadatas[0] if metadatas else None)
+
+                writer.writerow([
+                    keyword,
+                    collection_name,
+                    len(docs),
+                    first_hit_id,
+                    first_hit_page if first_hit_page is not None else "",
+                    latency_ms,
+                ])
+
+    return output_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Rulează un keyword sweep pe toate colecțiile Chroma.")
+    parser.add_argument(
+        "--keywords",
+        help="Fișier sau listă separată prin virgulă/spații cu cuvinte cheie.",
+    )
+    parser.add_argument(
+        "--output",
+        default=os.getenv("KEYWORD_SWEEP_OUTPUT", "keyword_sweep.csv"),
+        help="Path-ul fișierului CSV de ieșire.",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=3,
+        help="Numărul de rezultate căutate pentru fiecare keyword.",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    keywords = _parse_keyword_source(args.keywords)
+    output_path = Path(args.output)
+
+    keyword_sweep(keywords, output_path, top_k=args.top_k)
+    print(f"Keyword sweep completed. Results saved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- disable Chroma telemetry by default, clamp top-k queries and harden embeddings directory setup
- add maintenance CLI flags, keyword sweep utility, and configurable chunk sizing for Railway deployments
- introduce unit tests and CI workflow covering telemetry, search behaviour and converter probe logic, plus document environment variables

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d440d48eb8833091e2a75f3c723cf3